### PR TITLE
Fix GetFunctionPointer for Mono

### DIFF
--- a/src/Aeon.Emulator/Decoding/InstructionSet.cs
+++ b/src/Aeon.Emulator/Decoding/InstructionSet.cs
@@ -323,13 +323,19 @@ namespace Aeon.Emulator.Decoding
                 return null;
             }
         }
+        static readonly System.Reflection.FieldInfo methodPtr =
+            // .NET
+            typeof(Delegate).GetField("_methodPtrAux", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic) ??
+            // Mono
+            typeof(Delegate).GetField("interp_method", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+
         private static unsafe delegate*<VirtualMachine, void> GetFunctionPointer(OpcodeInfo opcode, int mode)
         {
             if (opcode == null)
                 return null;
 
             if (opcode.Emulators[mode] != null)
-                return (delegate*<VirtualMachine, void>)((IntPtr)typeof(Delegate).GetField("_methodPtrAux", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic).GetValue(opcode.Emulators[mode])).ToPointer();
+                return (delegate*<VirtualMachine, void>)((IntPtr)methodPtr.GetValue(opcode.Emulators[mode])).ToPointer();
 
             return null;
         }


### PR DESCRIPTION
On Mono (and WebAssembly), there is no `Delegate._methodPtrAux` member, instead the equivalent field `interp_method` can be accessed (see [Delegate.Mono.cs](https://github.com/dotnet/runtime/blob/46138473ce1bf952137f5c857ed4b947ebe58127/src/mono/System.Private.CoreLib/src/System/Delegate.Mono.cs)). I have tried to come up with a better solution, but there doesn't seem to be a supported option, since `RuntimeMethodHandle.GetFunctionPointer` doesn't work on dynamic methods. I have made a proposal (dotnet/runtime#78846) for a standard way do to this, but in the meantime this makes it working on other platforms (tested in Blazor WASM).