### PR TITLE
Add DOS SetFileAttributes support

### DIFF
--- a/src/Aeon.Emulator/Dos/DosHandler.cs
+++ b/src/Aeon.Emulator/Dos/DosHandler.cs
@@ -254,6 +254,10 @@ internal sealed class DosHandler : IInterruptHandler, IDisposable
                     case Functions.FileAttributes_GetFileAttributes:
                         fileControl.GetFileAttributes();
                         break;
+                        
+                    case Functions.FileAttributes_SetFileAttributes:
+                        fileControl.SetFileAttributes();
+                        break;
 
                     default:
                         throw new NotImplementedException($"DOS function 43{vm.Processor.AL:X2}h not implemented.");

--- a/src/Aeon.Emulator/Dos/Functions.cs
+++ b/src/Aeon.Emulator/Dos/Functions.cs
@@ -34,6 +34,7 @@ internal static class Functions
     public const byte SetInterruptVector = 0x25;
     public const byte FileAttributes = 0x43;
     public const byte FileAttributes_GetFileAttributes = 0x00;
+    public const byte FileAttributes_SetFileAttributes = 0x01;
     public const byte SetDiskTransferAreaAddress = 0x1A;
     public const byte GetDiskTransferAreaAddress = 0x2F;
     public const byte FindFirstFile = 0x4E;


### PR DESCRIPTION
## Why
🗂️ Found while running old archive extraction programs that expect to set file attributes on completion. Legacy archive/extraction utilities (e.g., some DOS-based unpackers) call INT 21h/43h/01h to adjust on-disk attributes. The emulator handled only the “get attributes” path (43h/00h), so these tools failed when trying to set read-only/hidden/system/archive bits after extraction.

📦 I was using the AIN and NULIB extractors, and happy to provide download links and archives to test on if needed. 

✅ Supporting the setter call brings parity with DOS behavior and lets these tools complete successfully.

## What
➕ Add FileAttributes_SetFileAttributes constant and route INT 21h/43h/01h in DosHandler.

🛠️ Implement FileControl.SetFileAttributes:
- Resolve DOS path, ensure a mapped drive exists and is writable.
- Validate the target exists (file or directory).
- Map DOS attributes to host attributes while preserving the directory flag.
- Apply attributes via File.SetAttributes, returning DOS error codes on failure.

🧰 Add helper to convert virtual file attributes to host attributes.

## Testing
🧪 dotnet build src/Aeon.slnx