### PR TITLE
Implement some missing MSCDEX functions

### DIFF
--- a/src/Aeon.Emulator/Dos/CD/IoctlReadFunction.cs
+++ b/src/Aeon.Emulator/Dos/CD/IoctlReadFunction.cs
@@ -1,0 +1,12 @@
+namespace Aeon.Emulator.Dos.CD;
+
+internal static class IoctlReadFunction
+{
+    public const byte DeviceHeaderAddress = 1;
+    public const byte DeviceStatus = 6;
+    public const byte VolumeSize = 8;
+    public const byte AudioDiscInfo = 10;
+    public const byte AudioTrackInfo = 11;
+    public const byte AudioQChannelInfo = 12;
+    public const byte AudioStatusInfo = 15;
+}

--- a/src/Aeon.Emulator/Dos/CD/IoctlWriteFunction.cs
+++ b/src/Aeon.Emulator/Dos/CD/IoctlWriteFunction.cs
@@ -1,0 +1,7 @@
+namespace Aeon.Emulator.Dos.CD;
+
+internal static class IoctlWriteFunction
+{
+    public const byte ResetDrive = 2;
+    public const byte AudioChannelControl = 3;
+}


### PR DESCRIPTION
This project is very useful for reverse engineering old games. Thank you for your work!

While testing it, I noticed that the MSCDEX implementation is missing a few functions required by some titles, so I went ahead and implemented some.

Adds several missing MSCDEX CD-ROM driver functions needed by some games:
- IOCTL Read subfunction 06h (Device Status)
- IOCTL Read subfunction 0Fh (Audio Status Info)
- Device request command 07h (Input Flush)
- Interrupt function ReadVTOC (Volume Table of Contents)

Replaces magic numbers in the IOCTL read/write switch statements with `IoctlReadFunction` and `IoctlWriteFunction` constants, consistent with the existing `CommandCodes` and `Functions` classes.

These additions allow games that query CD status and audio playback state to function correctly.