### PR TITLE
Fix transparent output in PixelFormatBGRA by setting alpha to fully opaque

### DIFF
--- a/src/Aeon.Emulator/Video/Rendering/PixelFormatBGRA.cs
+++ b/src/Aeon.Emulator/Video/Rendering/PixelFormatBGRA.cs
@@ -1,8 +1,14 @@
-﻿namespace Aeon.Emulator.Video.Rendering;
+namespace Aeon.Emulator.Video.Rendering;
 
 public readonly struct PixelFormatBGRA : IOutputPixelFormat
 {
-    public static void ConvertBGRAPalette(ReadOnlySpan<uint> bgraPalette, Span<uint> outputPalette) => bgraPalette.CopyTo(outputPalette);
+    public static void ConvertBGRAPalette(ReadOnlySpan<uint> bgraPalette, Span<uint> outputPalette)
+    {
+        for (int i = 0; i < bgraPalette.Length; i++)
+        {
+            outputPalette[i] = bgraPalette[i] | 0xFF000000u;
+        }
+    }
 
     private const double RedRatio = 255.0 / 31.0;
     private const double GreenRatio = 255.0 / 63.0;
@@ -14,8 +20,8 @@ public readonly struct PixelFormatBGRA : IOutputPixelFormat
         uint g = (uint)(((value & 0x07E0) >> 5) * GreenRatio) & 0xFFu;
         uint b = (uint)((value & 0x001F) * BlueRatio) & 0xFFu;
 
-        return (r << 16) | (g << 8) | b;
+        return (r << 16) | (g << 8) | b | 0xFF000000u;
     }
 
-    public static uint FromBGRA(uint value) => value;
+    public static uint FromBGRA(uint value) => value | 0xFF000000u;
 }


### PR DESCRIPTION
I hope you don't mind a little contribution, again ;-)

## The Problem...

`PixelFormatBGRA` never set the alpha channel in its output pixels, leaving it at 0x00 in all cases. The DAC stores palette colors as `0x00RRGGBB` and has no concept of transparency, so alpha should always be 0xFF.

This was invisible in the WPF host because `FastBitmap` uses `PixelFormats.Bgr32`, which treats the high byte as padding and ignores it entirely. Any renderer that respects the alpha channel (e.g. OpenGL with `Rgba8`) would see fully transparent pixels and display nothing.

## ... and how to fix it

- `FromRGB16`: OR `0xFF000000u` into the returned pixel value
- `FromBGRA`: OR `0xFF000000u` into the returned pixel value
- `ConvertBGRAPalette`: OR `0xFF000000u` onto each palette entry during conversion

The palette fix is necessary because palettized renderers (text, 8-bit, 4-bit, etc.) look up pre-converted palette entries directly and never go through `FromBGRA`.